### PR TITLE
add Job Template task generation function, Job Template task deletion…

### DIFF
--- a/tasker/job_template/generate.py
+++ b/tasker/job_template/generate.py
@@ -1,5 +1,6 @@
 from tasker.models import db, User, JobTemplate, Task, TaskStatus
-import datetime
+from pytz import timezone
+import datetime, pytz
 
 def generate_tasks(template_id):
     template = JobTemplate.query.get(template_id)
@@ -12,6 +13,8 @@ def generate_tasks(template_id):
         rep *= 30
     start = template.starting_date
     timestamp = datetime.datetime.fromtimestamp(start)
+    timestamp = timestamp.replace(hour=template.hour, minute=0)
+    timestamp = timestamp.astimezone(pytz.timezone(user.timezone))
     end = timestamp.replace(timestamp.year + 1)
     while timestamp <= end:
         task = Task.create_task(template.name, template.description,TaskStatus.Pending, timestamp)

--- a/tasker/job_template/generate.py
+++ b/tasker/job_template/generate.py
@@ -14,7 +14,6 @@ def generate_tasks(template_id):
     start = template.starting_date
     timestamp = datetime.datetime.fromtimestamp(start, tz=pytz.timezone(user.timezone))
     timestamp = timestamp.replace(hour=template.hour, minute=0)
-    #timestamp = timestamp.astimezone(pytz.timezone(user.timezone))
     end = timestamp.replace(timestamp.year + 1)
     while timestamp <= end:
         task = Task.create_task(template.name, template.description,TaskStatus.Pending, timestamp)

--- a/tasker/job_template/generate.py
+++ b/tasker/job_template/generate.py
@@ -12,9 +12,9 @@ def generate_tasks(template_id):
     if interval == 3:
         rep *= 30
     start = template.starting_date
-    timestamp = datetime.datetime.fromtimestamp(start)
+    timestamp = datetime.datetime.fromtimestamp(start, tz=pytz.timezone(user.timezone))
     timestamp = timestamp.replace(hour=template.hour, minute=0)
-    timestamp = timestamp.astimezone(pytz.timezone(user.timezone))
+    #timestamp = timestamp.astimezone(pytz.timezone(user.timezone))
     end = timestamp.replace(timestamp.year + 1)
     while timestamp <= end:
         task = Task.create_task(template.name, template.description,TaskStatus.Pending, timestamp)

--- a/tasker/job_template/generate.py
+++ b/tasker/job_template/generate.py
@@ -31,8 +31,6 @@ def delete_tasks(template_id):
     return 1
 
 def update_job_template(template_id):
-    template = JobTemplate.query.get(template_id)
-    user_id = template.owner.email_address
     delete_tasks(template_id)
     generate_tasks(template_id)
     return 1

--- a/tasker/job_template/generate.py
+++ b/tasker/job_template/generate.py
@@ -1,0 +1,38 @@
+from tasker.models import db, User, JobTemplate, Task, TaskStatus
+import datetime
+
+def generate_tasks(template_id):
+    template = JobTemplate.query.get(template_id)
+    user = template.owner
+    rep = template.repetition
+    interval = template.interval
+    if interval == 2:
+        rep *= 7
+    if interval == 3:
+        rep *= 30
+    start = template.starting_date
+    timestamp = datetime.datetime.fromtimestamp(start)
+    end = timestamp.replace(timestamp.year + 1)
+    while timestamp <= end:
+        task = Task.create_task(template.name, template.description,TaskStatus.Pending, timestamp)
+        task.owner = user
+        task.job_template = template
+        db.session.add(task)
+        db.session.commit()
+        timestamp += datetime.timedelta(days=rep)
+    return 1
+
+def delete_tasks(template_id):
+    template = JobTemplate.query.get(template_id)
+    tasks = Task.query.filter_by(job_template=template)
+    for t in tasks:
+        db.session.delete(t)
+    db.session.commit()
+    return 1
+
+def update_job_template(template_id):
+    template = JobTemplate.query.get(template_id)
+    user_id = template.owner.email_address
+    delete_tasks(template_id)
+    generate_tasks(template_id)
+    return 1

--- a/tasker/job_template/generate.py
+++ b/tasker/job_template/generate.py
@@ -18,8 +18,8 @@ def generate_tasks(template_id):
         task.owner = user
         task.job_template = template
         db.session.add(task)
-        db.session.commit()
         timestamp += datetime.timedelta(days=rep)
+    db.session.commit()
     return 1
 
 def delete_tasks(template_id):


### PR DESCRIPTION
This adds job_template/generate.py file with functions for Job Template related task generation, related task deletion, and related task update. I have tested all the functions in flask shell. 

Currently, the month interval reflects a 30 day period. Given time (or if someone knows a fast/easy fix) that could be refined to better reflect the exact day specified (and account for 28, 30, and 31 day months). I am going to open that as an issue and we can either address it or not depending on time/desire. 