### PR TITLE
Add email notifier

### DIFF
--- a/tasker/app.py
+++ b/tasker/app.py
@@ -35,8 +35,8 @@ def create_app(config_object='tasker.settings'):
     #from tasker import home
     #app.register_blueprint(home.views.blueprint)
 
-    from tasker import user
-    app.register_blueprint(user.views.bp)
+    #from tasker import user
+    #app.register_blueprint(user.views.bp)
 
     from tasker import job_template
     app.register_blueprint(job_template.views.bp)

--- a/tasker/notifier.py
+++ b/tasker/notifier.py
@@ -1,11 +1,28 @@
-import time
 import datetime
-from tasker.models import db, Task, TaskStatus
-from tasker import create_app
+import logging
+import time
+import sys
 
-import pytz
-import boto3
+from sqlalchemy.orm import joinedload
 from flask import render_template
+import boto3
+import pytz
+
+from tasker import create_app
+from tasker.models import db, Task, TaskStatus
+
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+handler = logging.StreamHandler(sys.stdout)
+handler.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)
+logging.getLogger('botocore.client').setLevel(logging.INFO)
+logging.getLogger('botocore.hooks').setLevel(logging.INFO)
+logging.getLogger('botocore.endpoint').setLevel(logging.INFO)
+logging.getLogger('botocore.auth').setLevel(logging.INFO)
 
 email_service = boto3.client('ses')
 # 30 minute time buffer for querying pending tasks
@@ -13,10 +30,13 @@ time_buffer = 60 * 30
 
 
 def send_email(task):
+    logging.debug('Formatting due date for task: %r', task)
     due_date = datetime.datetime.fromtimestamp(task.due_date, tz=pytz.timezone(task.owner.timezone))
     due_date = due_date.strftime('%B %d, %Y %I:%M%p')
+    logging.debug('Rendering templates for task: %r', task)
     html_template = render_template('notifier/email.html', task=task, due_date=due_date)
     text_template = render_template('notifier/email.txt', task=task, due_date=due_date)
+    logging.debug('Sending email to user: %s', task.user_email_address)
     response = email_service.send_email(
         Destination={'ToAddresses': [task.user_email_address]},
         Message={
@@ -40,20 +60,32 @@ def send_email(task):
 
 
 def notify():
+    logger.info('Starting up. Creating Flask app context.')
     app = create_app()
     with app.app_context():
         # Get all pending or snoozed tasks with
         # due dates less than 30 minutes from now
         time_guard = int(time.time() + time_buffer)
-        tasks = Task.query.filter(
-            Task.due_date < time_guard,
-            Task.status.in_([TaskStatus.Pending, TaskStatus.Snoozed])
+        logger.info('Querying for tasks pending or snoozed which are due before %s', time_guard)
+        tasks = list(Task.query.\
+            options(
+                joinedload(Task.owner)
+            ).\
+            filter(
+                Task.due_date < time_guard,
+                Task.status.in_([TaskStatus.Pending, TaskStatus.Snoozed])
+            )
         )
+        if not tasks:
+            logging.info('No tasks to process.')
         for task in tasks:
+            logging.info('Processing task: %r', task)
             send_email(task)
+            logging.info('Email sent for task: %r', task)
             task.status = TaskStatus.Due
             db.session.add(task)
             db.session.commit()
+            logging.info('Task status changed to pending: %r', task)
 
 
 if __name__ == '__main__':

--- a/tasker/notifier.py
+++ b/tasker/notifier.py
@@ -1,0 +1,60 @@
+import time
+import datetime
+from tasker.models import db, Task, TaskStatus
+from tasker import create_app
+
+import pytz
+import boto3
+from flask import render_template
+
+email_service = boto3.client('ses')
+# 30 minute time buffer for querying pending tasks
+time_buffer = 60 * 30
+
+
+def send_email(task):
+    due_date = datetime.datetime.fromtimestamp(task.due_date, tz=pytz.timezone(task.owner.timezone))
+    due_date = due_date.strftime('%B %d, %Y %I:%M%p')
+    html_template = render_template('notifier/email.html', task=task, due_date=due_date)
+    text_template = render_template('notifier/email.txt', task=task, due_date=due_date)
+    response = email_service.send_email(
+        Destination={'ToAddresses': [task.user_email_address]},
+        Message={
+            'Body': {
+                'Html': {
+                    'Charset': 'UTF-8',
+                    'Data': html_template
+                },
+                'Text': {
+                    'Charset': 'UTF-8',
+                    'Data': text_template
+                }
+            },
+            'Subject': {
+                'Charset': 'UTF-8',
+                'Data': f'Task Due - {task.name}'
+            }
+        },
+        Source='Tasker <app@tasker.nvram.io>'
+    )
+
+
+def notify():
+    app = create_app()
+    with app.app_context():
+        # Get all pending or snoozed tasks with
+        # due dates less than 30 minutes from now
+        time_guard = int(time.time() + time_buffer)
+        tasks = Task.query.filter(
+            Task.due_date < time_guard,
+            Task.status.in_([TaskStatus.Pending, TaskStatus.Snoozed])
+        )
+        for task in tasks:
+            send_email(task)
+            task.status = TaskStatus.Due
+            db.session.add(task)
+            db.session.commit()
+
+
+if __name__ == '__main__':
+    notify()

--- a/tasker/templates/notifier/email.html
+++ b/tasker/templates/notifier/email.html
@@ -1,0 +1,275 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+    <meta charset="utf-8"> <!-- utf-8 works for most cases -->
+    <meta name="viewport" content="width=device-width"> <!-- Forcing initial-scale shouldn't be necessary -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"> <!-- Use the latest (edge) version of IE rendering engine -->
+    <meta name="x-apple-disable-message-reformatting">  <!-- Disable auto-scale in iOS 10 Mail entirely -->
+    <meta name="format-detection" content="telephone=no,address=no,email=no,date=no,url=no"> <!-- Tell iOS not to automatically link certain text strings. -->
+    <meta name="color-scheme" content="light">
+    <meta name="supported-color-schemes" content="light">
+    <title>Task Due - {{ task.name }}</title> <!--   The title tag shows in email notifications, like Android 4.4. -->
+
+    <!-- What it does: Makes background images in 72ppi Outlook render at correct size. -->
+    <!--[if gte mso 9]>
+    <xml>
+        <o:OfficeDocumentSettings>
+            <o:AllowPNG/>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+    </xml>
+    <![endif]-->
+
+    <!-- Web Font / @font-face : BEGIN -->
+    <!-- NOTE: If web fonts are not required, lines 23 - 41 can be safely removed. -->
+
+    <!-- Desktop Outlook chokes on web font references and defaults to Times New Roman, so we force a safe fallback font. -->
+    <!--[if mso]>
+        <style>
+            * {
+                font-family: sans-serif !important;
+            }
+        </style>
+    <![endif]-->
+
+    <!-- All other clients get the webfont reference; some will render the font and others will silently fail to the fallbacks. More on that here: http://stylecampaign.com/blog/2015/02/webfont-support-in-email/ -->
+    <!--[if !mso]><!-->
+    <!-- insert web font reference, eg: <link href='https://fonts.googleapis.com/css?family=Roboto:400,700' rel='stylesheet' type='text/css'> -->
+    <!--<![endif]-->
+
+    <!-- Web Font / @font-face : END -->
+
+    <!-- CSS Reset : BEGIN -->
+    <style>
+
+        /* What it does: Tells the email client that only light styles are provided but the client can transform them to dark. A duplicate of meta color-scheme meta tag above. */
+        :root {
+          color-scheme: light;
+          supported-color-schemes: light;
+        }
+
+        /* What it does: Remove spaces around the email design added by some email clients. */
+        /* Beware: It can remove the padding / margin and add a background color to the compose a reply window. */
+        html,
+        body {
+            margin: 0 auto !important;
+            padding: 0 !important;
+            height: 100% !important;
+            width: 100% !important;
+        }
+
+        /* What it does: Stops email clients resizing small text. */
+        * {
+            -ms-text-size-adjust: 100%;
+            -webkit-text-size-adjust: 100%;
+        }
+
+        /* What it does: Centers email on Android 4.4 */
+        div[style*="margin: 16px 0"] {
+            margin: 0 !important;
+        }
+
+        /* What it does: forces Samsung Android mail clients to use the entire viewport */
+        #MessageViewBody, #MessageWebViewDiv{
+            width: 100% !important;
+        }
+
+        /* What it does: Stops Outlook from adding extra spacing to tables. */
+        table,
+        td {
+            mso-table-lspace: 0pt !important;
+            mso-table-rspace: 0pt !important;
+        }
+
+        /* What it does: Fixes webkit padding issue. */
+        table {
+            border-spacing: 0 !important;
+            border-collapse: collapse !important;
+            table-layout: fixed !important;
+            margin: 0 auto !important;
+        }
+
+        /* What it does: Uses a better rendering method when resizing images in IE. */
+        img {
+            -ms-interpolation-mode:bicubic;
+        }
+
+        /* What it does: Prevents Windows 10 Mail from underlining links despite inline CSS. Styles for underlined links should be inline. */
+        a {
+            text-decoration: none;
+        }
+
+        /* What it does: A work-around for email clients meddling in triggered links. */
+        a[x-apple-data-detectors],  /* iOS */
+        .unstyle-auto-detected-links a,
+        .aBn {
+            border-bottom: 0 !important;
+            cursor: default !important;
+            color: inherit !important;
+            text-decoration: none !important;
+            font-size: inherit !important;
+            font-family: inherit !important;
+            font-weight: inherit !important;
+            line-height: inherit !important;
+        }
+
+        /* What it does: Prevents Gmail from displaying a download button on large, non-linked images. */
+        .a6S {
+            display: none !important;
+            opacity: 0.01 !important;
+        }
+
+        /* What it does: Prevents Gmail from changing the text color in conversation threads. */
+        .im {
+            color: inherit !important;
+        }
+
+        /* If the above doesn't work, add a .g-img class to any image in question. */
+        img.g-img + div {
+            display: none !important;
+        }
+
+        /* What it does: Removes right gutter in Gmail iOS app: https://github.com/TedGoas/Cerberus/issues/89  */
+        /* Create one of these media queries for each additional viewport size you'd like to fix */
+
+        /* iPhone 4, 4S, 5, 5S, 5C, and 5SE */
+        @media only screen and (min-device-width: 320px) and (max-device-width: 374px) {
+            u ~ div .email-container {
+                min-width: 320px !important;
+            }
+        }
+        /* iPhone 6, 6S, 7, 8, and X */
+        @media only screen and (min-device-width: 375px) and (max-device-width: 413px) {
+            u ~ div .email-container {
+                min-width: 375px !important;
+            }
+        }
+        /* iPhone 6+, 7+, and 8+ */
+        @media only screen and (min-device-width: 414px) {
+            u ~ div .email-container {
+                min-width: 414px !important;
+            }
+        }
+
+    </style>
+    <!-- CSS Reset : END -->
+
+    <!-- Progressive Enhancements : BEGIN -->
+    <style>
+
+	    /* What it does: Hover styles for buttons */
+	    .button-td,
+	    .button-a {
+	        transition: all 100ms ease-in;
+	    }
+	    .button-td-primary:hover,
+	    .button-a-primary:hover {
+	        background: #555555 !important;
+	        border-color: #555555 !important;
+	    }
+
+	    /* Media Queries */
+	    @media screen and (max-width: 600px) {
+
+	        /* What it does: Adjust typography on small screens to improve readability */
+	        .email-container p {
+	            font-size: 17px !important;
+	        }
+
+	    }
+
+    </style>
+    <!-- Progressive Enhancements : END -->
+
+</head>
+<!--
+	The email background color (#222222) is defined in three places:
+	1. body tag: for most email clients
+	2. center tag: for Gmail and Inbox mobile apps and web versions of Gmail, GSuite, Inbox, Yahoo, AOL, Libero, Comcast, freenet, Mail.ru, Orange.fr
+	3. mso conditional: For Windows 10 Mail
+-->
+<body width="100%" style="margin: 0; padding: 0 !important; mso-line-height-rule: exactly; background-color: #222222;">
+	<center role="article" aria-roledescription="email" lang="en" style="width: 100%; background-color: #222222;">
+    <!--[if mso | IE]>
+    <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color: #222222;">
+    <tr>
+    <td>
+    <![endif]-->
+
+        <!-- Visually Hidden Preheader Text : BEGIN -->
+        <div style="max-height:0; overflow:hidden; mso-hide:all;" aria-hidden="true">
+            Task Due - {{ task.name }}
+        </div>
+        <!-- Visually Hidden Preheader Text : END -->
+
+        <!-- Create white space after the desired preview text so email clients don’t pull other distracting text into the inbox preview. Extend as necessary. -->
+        <!-- Preview Text Spacing Hack : BEGIN -->
+        <div style="display: none; font-size: 1px; line-height: 1px; max-height: 0px; max-width: 0px; opacity: 0; overflow: hidden; mso-hide: all; font-family: sans-serif;">
+	        &zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;
+        </div>
+        <!-- Preview Text Spacing Hack : END -->
+
+        <!--
+            Set the email width. Defined in two places:
+            1. max-width for all clients except Desktop Windows Outlook, allowing the email to squish on narrow but never go wider than 600px.
+            2. MSO tags for Desktop Windows Outlook enforce a 600px width.
+        -->
+        <div style="max-width: 600px; margin: 0 auto;" class="email-container">
+            <!--[if mso]>
+            <table align="center" role="presentation" cellspacing="0" cellpadding="0" border="0" width="600">
+            <tr>
+            <td>
+            <![endif]-->
+
+	        <!-- Email Body : BEGIN -->
+	        <table align="center" role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: auto;">
+		        <!-- Email Header : BEGIN -->
+	            <tr>
+	                <td style="padding: 20px 0; text-align: center">
+	                    <img src="https://static.tasker.nvram.io/icon.png" width="200" height="50" alt="alt_text" border="0" style="height: auto; background: #dddddd; font-family: sans-serif; font-size: 15px; line-height: 15px; color: #555555;">
+	                </td>
+	            </tr>
+		        <!-- Email Header : END -->
+
+                <!-- 1 Column Text + Button : BEGIN -->
+                <tr>
+                    <td style="background-color: #ffffff;">
+                        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                            <tr>
+                                <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
+                                    <h1 style="margin: 0 0 10px 0; font-family: sans-serif; font-size: 25px; line-height: 30px; color: #333333; font-weight: normal;">Task Due: {{ task.name }}</h1>
+                                    <h2 style="margin: 0 0 10px 0; font-family: sans-serif; font-size: 15px; line-height: 30px; color: #333333; font-weight: normal;">Due Date: {{ due_date }}</h2>
+                                    <p style="margin: 0;">{{ task.description }}</p>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                <!-- 1 Column Text + Button : END -->
+                <!-- Clear Spacer : BEGIN -->
+                <tr>
+                    <td aria-hidden="true" height="40" style="font-size: 0px; line-height: 0px;">
+                        &nbsp;
+                    </td>
+                </tr>
+                <!-- Clear Spacer : END -->
+
+            </table>
+            <!-- Email Body : END -->
+
+
+            <!--[if mso]>
+            </td>
+            </tr>
+            </table>
+            <![endif]-->
+        </div>
+
+    <!--[if mso | IE]>
+    </td>
+    </tr>
+    </table>
+    <![endif]-->
+    </center>
+</body>
+</html>

--- a/tasker/templates/notifier/email.txt
+++ b/tasker/templates/notifier/email.txt
@@ -1,0 +1,4 @@
+Task Due: {{ task.name }}
+Due Date: {{ due_date }}
+
+{{ task.description }}


### PR DESCRIPTION
The email notifier has three main parts:
  1. Getting a list of pending tasks
  2. Sending the email for a pending task
  3. Changing status of a pending task to due

For 1, the query is for any pending tasks with due dates that are earlier than 30 minutes ahead of the current moment.  The logic is that the notifier will be run hourly.  To make sure pending tasks due on that hour are not missed, instead of checking based on the exact hourly timestamp, the boundary is set 30 minutes ahead.